### PR TITLE
Add an example of the same wrapper using cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-cython_sieve.cpp
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -132,3 +130,6 @@ dmypy.json
 
 # macOS files
 .DS_Store
+
+# Cython generated file
+cython_sieve.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+cython_sieve.cpp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cython_sieve.pyx
+++ b/cython_sieve.pyx
@@ -1,0 +1,7 @@
+cimport sieve
+
+def sieve_of_eratosthenes(size_t n):
+    '''
+    Return list of prime numbers until given number. Implemented in Cython.
+    '''
+    return sieve.SieveOfEratosthenes(n)

--- a/cython_sieve.pyx
+++ b/cython_sieve.pyx
@@ -1,5 +1,6 @@
 cimport sieve
 
+
 def sieve_of_eratosthenes(size_t n):
     '''
     Return list of prime numbers until given number. Implemented in Cython.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, Extension
 import sysconfig
 
+from Cython.Build import cythonize
+
 
 language = 'c++'
 std = 'c++17'
@@ -18,9 +20,16 @@ extension = Extension(
     language=language
 )
 
+cython_extension = Extension(
+    'cython_sieve',
+    sources=['cython_sieve.pyx', 'sieve.cpp'],
+    extra_compile_args=extra_compile_args,
+    language='c++',
+)
+
 setup(
     name='cpp_python_extension',
     version='1.0',
     description='This is Example module written in C++',
-    ext_modules=[extension]
+    ext_modules=cythonize([extension, cython_extension]),
 )

--- a/sieve.pxd
+++ b/sieve.pxd
@@ -1,0 +1,4 @@
+from libcpp.vector cimport vector
+
+cdef extern from "sieve.h" namespace "abc":
+    vector[size_t] SieveOfEratosthenes(size_t n)

--- a/sieve.pxd
+++ b/sieve.pxd
@@ -1,4 +1,5 @@
 from libcpp.vector cimport vector
 
+
 cdef extern from "sieve.h" namespace "abc":
     vector[size_t] SieveOfEratosthenes(size_t n)

--- a/test_benchmark.py
+++ b/test_benchmark.py
@@ -1,7 +1,12 @@
 import pytest
 import cpp_python_extension
+import cython_sieve
 
 
 @pytest.mark.parametrize("input", [1000, 100000, 1000000])
 def test_cpp(benchmark, input):
     benchmark(cpp_python_extension.sieve_of_eratosthenes, input)
+
+@pytest.mark.parametrize("input", [1000, 100000, 1000000])
+def test_cyth(benchmark, input):
+    benchmark(cython_sieve.sieve_of_eratosthenes, input)


### PR DESCRIPTION
I appreciate that initially this was an exercise in implementing an extension using only the raw CPython API. However if the goal is to provide a simple example of how to extend python with C++ extensions, it might be worthwhile to have the same thing spelled in Cython, just for convenience of comparison.